### PR TITLE
Add support for DS1621+ and DS1821+

### DIFF
--- a/build-in-docker.sh
+++ b/build-in-docker.sh
@@ -20,7 +20,7 @@ for d in /toolkit/build_env/* ; do
 done
 
 export OVERRIDE_PKGARCH_armv7="alpine alpine4k armadaxp armada375 armada38x monaco"
-export OVERRIDE_PKGARCH_x86_64="x86 bromolow cedarview avoton braswell broadwell dockerx64 kvmx64 grantley denverton apollolake broadwellnk geminilake"
+export OVERRIDE_PKGARCH_x86_64="x86 bromolow cedarview avoton braswell broadwell dockerx64 kvmx64 grantley denverton apollolake broadwellnk geminilake v1000"
 
 pushd /toolkit >/dev/null
 ./pkgscripts-ng/PkgCreate.py -c syncthing


### PR DESCRIPTION
Taking info from several sources, it seems like the AMD Ryzen V1500B is a X86_64 processor.

- https://github.com/SynoCommunity/spksrc/issues/4170
- https://github.com/eizedev/AirConnect-Synology/commit/80f7c87580b1f8d203a51196589ffe52524a5322